### PR TITLE
Add repository information to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,13 @@
     "@octokit/rest": "^15.2.6",
     "ora": "^2.0.0",
     "yargs": "^11.0.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/suchipi/prs-merged-since.git"
+  },
+  "bugs": {
+    "url": "https://github.com/suchipi/prs-merged-since/issues"
+  },
+  "homepage": "https://github.com/suchipi/prs-merged-since#readme"
 }


### PR DESCRIPTION
This helps folks using either npmjs.com or `npm docs` to find the repo.